### PR TITLE
Feature/move parametrization method

### DIFF
--- a/dingo/core/__init__.py
+++ b/dingo/core/__init__.py
@@ -220,7 +220,7 @@ class NetworkDingo:
         # TODO: Breath life into this method :). Prior to this the table structure has to be defined
 
     def mv_routing(self, debug=False):
-        """ Performs routing on all MV grids, see method `routing` in class `MVGridDingo` for details
+        """ Performs routing on all MV grids, see method `routing` in class `MVGridDingo` for details.
 
         Args:
             debug: If True, information is printed while routing
@@ -229,32 +229,16 @@ class NetworkDingo:
         for region in self.mv_regions():
             region.mv_grid.routing(debug)
 
-    def parametrize_grid(self):
-        """Parametrization of grid equipment"""
+    def mv_parametrize_grid(self, debug=False):
+        """ Performs Parametrization of grid equipment of all MV grids, see method `parametrize_grid` in class
+            `MVGridDingo` for details.
 
-        # Parameters of possible transformers
-        # TODO: move to database of config file
-        transformers = {
-            20000: {
-                'voltage_level': 20,
-                'apparent_power': 20000},
-            31500: {
-                'voltage_level': 10,
-                'apparent_power': 31500},
-            40000: {
-                'voltage_level': 10,
-                'apparent_power': 40000}}
+        Args:
+            debug: If True, information is printed while parametrization
+        """
 
-        for mv_region in self._mv_regions:
-
-            # choose appropriate transformers for each sub-station
-            mv_region.mv_grid._station.choose_transformers(transformers,
-               **{'peak_load': mv_region.peak_load})
-
-            # choose appropriate type of line/cable for each edge
-            mv_region.mv_grid.parametrize_lines(mv_region.peak_load,
-                                                mv_region.mv_grid.region.geo_data.area)
+        for region in self.mv_regions():
+            region.mv_grid.parametrize_grid(debug)
 
     def __repr__(self):
         return str(self.name)
-    

--- a/dingo/core/network/__init__.py
+++ b/dingo/core/network/__init__.py
@@ -98,7 +98,7 @@ class StationDingo():
         # TODO: check arg
         if transformer not in self.transformers() and isinstance(transformer, TransformerDingo):
             self._transformers.append(transformer)
-
+        # TODO: what if it exists? -> error message
 
 class BusDingo(Bus):
     """ Create new pypower Bus class as child from oemof Bus used to define

--- a/dingo/core/network/grids.py
+++ b/dingo/core/network/grids.py
@@ -79,6 +79,36 @@ class MVGridDingo(GridDingo):
         #     mv_branches[edge] = mv_branch
         # nx.set_edge_attributes(self._graph, 'branch', mv_branches)
 
+    def parametrize_grid(self, debug=False):
+        """ Performs Parametrization of grid equipment.
+
+        Args:
+            debug: If True, information is printed while routing
+        """
+        # TODO: Add more detailed description
+
+        # Parameters of possible transformers
+        # TODO: move to database of config file
+        transformers = {
+            20000: {
+                'voltage_level': 20,
+                'apparent_power': 20000},
+            31500: {
+                'voltage_level': 10,
+                'apparent_power': 31500},
+            40000: {
+                'voltage_level': 10,
+                'apparent_power': 40000}}
+
+
+        # choose appropriate transformers for each sub-station
+        self._station.choose_transformers(transformers,
+                                          **{'peak_load': self.region.peak_load})
+
+        # choose appropriate type of line/cable for each edge
+        self.parametrize_lines(self.region.peak_load,
+                               self.region.geo_data.area)
+
 
     def parametrize_lines(self, peak_load, mv_region_area):
         """Chooses line/cable type and defines parameters
@@ -91,7 +121,7 @@ class MVGridDingo(GridDingo):
         Parameters
         ----------
         peak_load : numeric
-            peak load in the according mv_regiom
+            peak load in the according mv_region
         mv_region_area : numeric
             mv_region's area
 
@@ -125,6 +155,7 @@ class MVGridDingo(GridDingo):
         """
 
         # load cable/line parameters
+        # TODO: Move filenames to dingo config file
         package_path = dingo.__path__[0]
         line_parameter = pd.read_csv(os.path.join(package_path, 'data',
             'equipment-parameters_overhead_lines.csv'),
@@ -167,6 +198,7 @@ class MVGridDingo(GridDingo):
                 # choose line/cable type according to peak load of mv_grid
                 if branch_type is 'line':
                     # TODO: cross-check is multiplication by 3 is right
+                    # TODO: move constant value 0.6 (load factor) to config file
                     line_name = line_parameter.ix[line_parameter[
                         line_parameter['i_max_th'] * 3 * 0.6 >= peak_current]
                     ['i_max_th'].idxmin()]['name']

--- a/dingo/core/network/stations.py
+++ b/dingo/core/network/stations.py
@@ -66,7 +66,7 @@ class MVStationDingo(StationDingo):
                 selected_app_power = max(possible_tranformers)
             else:
                 selected_app_power = min(list(compress(possible_tranformers,
-                    [residual_apparent_power<=k
+                    [residual_apparent_power <= k
                      for k in possible_tranformers])))
 
             # add tranformer on determined size with according parameters
@@ -74,7 +74,7 @@ class MVStationDingo(StationDingo):
                 's_max_longterm': selected_app_power}))
             residual_apparent_power -= selected_app_power
 
-        # add redundant transformer of the size of the largest tranformer
+        # add redundant transformer of the size of the largest transformer
         s_max_max = max((o.s_max_a for o in self._transformers))
         int_kwargs = {'v_level': voltage_level,
                       's_max_longterm': s_max_max}

--- a/dingo/core/network/stations.py
+++ b/dingo/core/network/stations.py
@@ -14,7 +14,7 @@ class MVStationDingo(StationDingo):
     def __repr__(self):
         return 'mvstation_' + str(self.id_db)
 
-    def choose_transformers(self, transformers, **kwargs):
+    def choose_transformers(self, transformers, peak_load=None, **kwargs):
         """Chooses appropriate transformers for the MV sub-station
 
         Choice bases on voltage level (depends on load density), apparent power
@@ -46,30 +46,30 @@ class MVStationDingo(StationDingo):
         # TODO: derive voltage level by load density of mv_region
         voltage_level = 10 # in kV
 
-        apparent_power = kwargs.get('peak_load', None) # kW
-        possible_tranformers = []   # keys of above dict
+        apparent_power = peak_load  # kW
+        possible_transformers = []   # keys of above dict
 
         # put all keys of suitable transformers (based on voltage) to list
         for trans in transformers:
             if voltage_level == transformers[trans]['voltage_level']:
-                possible_tranformers.append(trans)
+                possible_transformers.append(trans)
 
         # step 2: determine number and size of required transformers
         residual_apparent_power = apparent_power
 
-        apparent_power_list = [transformers[x]['apparent_power']
-                               for x in possible_tranformers]
+        apparent_power_list = [transformers[_]['apparent_power']
+                               for _ in possible_transformers]
 
         while residual_apparent_power > 0:
             # TODO: move constant value 0.6 (load factor) to config file
-            if residual_apparent_power > 0.6 * max(possible_tranformers):
-                selected_app_power = max(possible_tranformers)
+            if residual_apparent_power > 0.6 * max(possible_transformers):
+                selected_app_power = max(possible_transformers)
             else:
-                selected_app_power = min(list(compress(possible_tranformers,
+                selected_app_power = min(list(compress(possible_transformers,
                     [residual_apparent_power <= k
-                     for k in possible_tranformers])))
+                     for k in possible_transformers])))
 
-            # add tranformer on determined size with according parameters
+            # add transformer on determined size with according parameters
             self.add_transformer(TransformerDingo(**{'v_level': voltage_level,
                 's_max_longterm': selected_app_power}))
             residual_apparent_power -= selected_app_power

--- a/test_dingo2.py
+++ b/test_dingo2.py
@@ -35,7 +35,7 @@ conn.close()
 
 nd.mv_routing()
 
-nd.parametrize_grid()
+nd.mv_parametrize_grid()
 
 #df = nx.to_pandas_dataframe(nd._mv_regions[0].mv_grid._graph)
 # import pprint


### PR DESCRIPTION
Move content of Network class' method 'parametrize_grid' to new method 'parametrize_grid' of class MVgrid for consequent class-method-structure (like method 'routing' in MVgrid class). Leave original method with loop.